### PR TITLE
Add http file support & Minor changes

### DIFF
--- a/Slipe-CLI/Commands/Project/Compilation/BuildCommand.cs
+++ b/Slipe-CLI/Commands/Project/Compilation/BuildCommand.cs
@@ -103,7 +103,7 @@ namespace Slipe.Commands.Project
 
                 if (content.Length > 0)
                 {
-                    string url = "http://luac.mtasa.com?compile=1&debug=0&obfuscate=2";
+                    string url = "http://luac.mtasa.com?compile=1&debug=0&obfuscate=3";
                     var result = await httpClient.PostAsync(url, new ByteArrayContent(content));
                     var compiledLua = await result.Content.ReadAsByteArrayAsync();
                     File.Delete(file);

--- a/Slipe-CLI/Commands/Project/Compilation/BuildCommand.cs
+++ b/Slipe-CLI/Commands/Project/Compilation/BuildCommand.cs
@@ -43,11 +43,21 @@ namespace Slipe.Commands.Project
                 CopyFiles("./" + directory.path, outputDirectory + "/" + directory.path);
             }
 
+            foreach (SlipeHttpDirectory directory in config.httpDirectories)
+            {
+                CopyFiles("./" + directory.path, outputDirectory + "/" + directory.path);
+            }
+
             foreach (SlipeModule module in config.modules)
             {
                 CopyFiles(module.path + "/Lua", outputDirectory + "/" + module.path + "/Lua");
 
                 foreach(SlipeAssetDirectory directory in module.assetDirectories)
+                {
+                    CopyFiles(module.path + "/" + directory.path, outputDirectory + "/" + module.path + "/" + directory.path);
+                }
+
+                foreach (SlipeHttpDirectory directory in module.httpDirectories)
                 {
                     CopyFiles(module.path + "/" + directory.path, outputDirectory + "/" + module.path + "/" + directory.path);
                 }

--- a/Slipe-CLI/Commands/Project/Compilation/CompileCommand.cs
+++ b/Slipe-CLI/Commands/Project/Compilation/CompileCommand.cs
@@ -370,7 +370,7 @@ namespace Slipe.Commands.Project
             {
                 if (export.type == "client")
                 {
-                    clientExports += string.Format("function {0}(...)\n\t{1}(...)\nend\n", export.niceName, export.name);
+                    clientExports += string.Format("function {0}(...)\n\treturn {1}(...)\nend\n", export.niceName, export.name);
                 }
             }
             clientExports += "";
@@ -382,7 +382,7 @@ namespace Slipe.Commands.Project
             {
                 if (export.type == "server")
                 {
-                    serverExports += string.Format("function {0}(...)\n\t{1}(...)\nend\n", export.niceName, export.name);
+                    serverExports += string.Format("function {0}(...)\n\treturn {1}(...)\nend\n", export.niceName, export.name);
                 }
             }
             serverExports += "";

--- a/Slipe-CLI/Commands/Project/Compilation/GenerateMetaCommand.cs
+++ b/Slipe-CLI/Commands/Project/Compilation/GenerateMetaCommand.cs
@@ -224,7 +224,7 @@ namespace Slipe.Commands.Project
                 {
                     relativePath = relativePath.Substring(1);
                 }
-                XmlElement element = meta.CreateElement("file");
+                XmlElement element = meta.CreateElement("html");
                 element.SetAttribute("src", relativePath);
                 element.SetAttribute("raw", "true");
                 if (relativePath == defaultFile)

--- a/Slipe-CLI/Commands/Project/HttpFiles/AddHttpDirectoryCommand.cs
+++ b/Slipe-CLI/Commands/Project/HttpFiles/AddHttpDirectoryCommand.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Slipe.Commands.Project.HttpFiles
+{
+    class AddHttpDirectoryCommand : ProjectCommand
+    {
+        public override string Template => "add-http";
+
+        public override void Run()
+        {
+            if (parameters.Count < 1)
+            {
+                throw new SlipeException("Please specify the project name, syntax: \n"  + Template + " {directory-path}");
+            }
+
+            string httpDirectory = parameters[0];
+
+            SlipeHttpDirectory directory = new SlipeHttpDirectory
+            {
+                path = httpDirectory,
+            };
+
+            if (targetsModule)
+            {
+                targetModule.httpDirectories.Add(directory);
+            }
+            else
+            {
+                config.httpDirectories.Add(directory);
+            }
+
+            Console.WriteLine("Success. You can specify the interpreted files in .slipe file.");
+        }
+    }
+}

--- a/Slipe-CLI/Commands/Project/HttpFiles/RemoveHttpDirectoryCommand .cs
+++ b/Slipe-CLI/Commands/Project/HttpFiles/RemoveHttpDirectoryCommand .cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+
+namespace Slipe.Commands.Project.HttpFiles
+{
+    class RemoveHttpDirectoryCommand : ProjectCommand
+    {
+        public override string Template => "remove-http";
+
+        public override void Run()
+        {
+            if (parameters.Count < 1)
+            {
+                throw new SlipeException("Please specify the project name, syntax: \n"  + Template + " {directory-path}");
+            }
+
+            string httpDirectory = parameters[0];
+
+            SlipeAssetDirectory directory = new SlipeAssetDirectory
+            {
+                path = httpDirectory,
+            };
+
+            if (targetsModule)
+            {
+                targetModule.httpDirectories.RemoveAll((directory) => directory.path == httpDirectory);
+            }
+            else
+            {
+                config.httpDirectories.RemoveAll((directory) => directory.path == httpDirectory);
+            }
+        }
+    }
+}

--- a/Slipe-CLI/Commands/Project/HttpFiles/SetDefaultHttpFile.cs
+++ b/Slipe-CLI/Commands/Project/HttpFiles/SetDefaultHttpFile.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Slipe.Commands.Project.HttpFiles
+{
+    class SetDefaultHttpFile : ProjectCommand
+    {
+        public override string Template => "set-default-http";
+
+        public override void Run()
+        {
+            if (parameters.Count < 1)
+            {
+                throw new SlipeException("Please specify the project name, syntax: \n"  + Template + " {file-path}");
+            }
+
+            string httpFilePath = parameters[0];
+            if (targetsModule)
+            {
+                throw new SlipeException("This command is not available with modules!");
+            }
+            else
+            {
+                config.defaultHttpFile = httpFilePath;
+            }
+
+            Console.WriteLine("Success. You can specify the interpreted files in .slipe file.");
+        }
+    }
+}

--- a/Slipe-CLI/SlipeConfig.cs
+++ b/Slipe-CLI/SlipeConfig.cs
@@ -45,10 +45,14 @@ namespace Slipe
         public List<string> dlls = new List<string>();
         public List<string> systemComponents = new List<string>();
         public List<SlipeAssetDirectory> assetDirectories = new List<SlipeAssetDirectory>();
+        public List<SlipeHttpDirectory> httpDirectories = new List<SlipeHttpDirectory>();
         public List<SlipeModule> modules = new List<SlipeModule>();
         public List<SlipeExport> exports = new List<SlipeExport>();
         public string clientMinVersion;
         public string serverMinVersion;
+
+        public string defaultHttpFile = "";
+
     }
 
     class SlipeConfigCompileTargetList
@@ -90,6 +94,8 @@ namespace Slipe
         public List<string> systemComponents = new List<string>();
         public List<string> backingLua = new List<string>();
         public List<SlipeAssetDirectory> assetDirectories = new List<SlipeAssetDirectory>();
+
+        public List<SlipeHttpDirectory> httpDirectories = new List<SlipeHttpDirectory>();
     }
 
     class SlipeAssetDirectory
@@ -105,5 +111,11 @@ namespace Slipe
         public string niceName;
         public string type;
         public bool isHttp;
+    }
+
+    class SlipeHttpDirectory
+    {
+        public string path;
+        public List<string> interpretedFiles = new List<string>();
     }
 }

--- a/SlipeWpfInstaller/SlipeWpfInstaller.csproj
+++ b/SlipeWpfInstaller/SlipeWpfInstaller.csproj
@@ -6,7 +6,7 @@
     <UseWPF>true</UseWPF>
     <ApplicationIcon>favicon.ico</ApplicationIcon>
     <PublishSingleFile>true</PublishSingleFile>
-    <PublishTrimmed>true</PublishTrimmed>
+    <PublishTrimmed>false</PublishTrimmed>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
 


### PR DESCRIPTION
New commands:

- `add-http {directory-path}` Add new http directory
- `remove-http {directory-path}` Remove the specific http directory
- `set-default-http {file-path}` Set the default http file for the resource

Minor changes:

- Return value for exports
- Upgrade luac obfuscation level (2 -> 3)